### PR TITLE
Env fix for CPU only machines

### DIFF
--- a/utils/setup_conda.sh
+++ b/utils/setup_conda.sh
@@ -87,7 +87,7 @@ cat <<EOF > ${ENV_FN_NAME}
 #!/bin/bash
 
 source ${CONDA_INSTALL_DIR}/bin/activate ${ENV_NAME}
-torch_ccl_path=\$(python -c "import torch; import oneccl_bindings_for_pytorch; import os;  print(os.path.abspath(os.path.dirname(oneccl_bindings_for_pytorch.__file__)))" 2> /dev/null | grep oneccl_bind_pt )
+torch_ccl_path=\$(python -c "import torch; import oneccl_bindings_for_pytorch; import os;  print(os.path.abspath(os.path.dirname(oneccl_bindings_for_pytorch.__file__)))" 2> /dev/null | grep oneccl_bind_pt |tail -n 1)
 if test -f \$torch_ccl_path/env/setvars.sh ; then
   source \$torch_ccl_path/env/setvars.sh
 fi


### PR DESCRIPTION
Env fix for the below warning being displayed for CPU only systems.

Warning: Cannot load xpu CCL. CCL doesn't work for XPU device due to /home/.../tpp-pytorch-extension/miniforge3/envs/pt251/lib/python3.9/site-packages/oneccl_bind_pt-2.4.0+cpu-py3.9-linux-x86_64.egg/oneccl_bindings_for_pytorch/lib/liboneccl_bindings_for_pytorch_xpu.so: cannot open shared object file: No such file or directory
